### PR TITLE
Use traditional import instead of module import

### DIFF
--- a/BKDeltaCalculator/BKDeltaCalculator.h
+++ b/BKDeltaCalculator/BKDeltaCalculator.h
@@ -1,7 +1,7 @@
 // Copyright 2014-present 650 Industries.
 // Copyright 2014-present Andrew Toulouse.
 
-@import Foundation;
+#import <Foundation/Foundation.h>
 
 @class BKDelta;
 


### PR DESCRIPTION
So BKDeltaCalculator.h is usable from Objective-C++.

@ide 
