### PR TITLE
Add 'extern' declaration to strict equality test block

### DIFF
--- a/BKDeltaCalculator/BKDeltaCalculator.h
+++ b/BKDeltaCalculator/BKDeltaCalculator.h
@@ -7,7 +7,7 @@
 
 typedef BOOL (^delta_calculator_equality_test_t)(id a, id b);
 
-const delta_calculator_equality_test_t BKDeltaCalculatorStrictEqualityTest;
+extern const delta_calculator_equality_test_t BKDeltaCalculatorStrictEqualityTest;
 
 @interface BKDeltaCalculator : NSObject
 


### PR DESCRIPTION
Missed this while updating for Objective-C++ compatibility.

@ide 

Gonna merge without review because of time constraints.
